### PR TITLE
Add Jest and test for callAPIWithRetry

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/app/api/__tests__/callAPIWithRetry.test.js
+++ b/app/api/__tests__/callAPIWithRetry.test.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { callAPIWithRetry } from '../route/route';
+
+jest.mock('axios');
+
+describe('callAPIWithRetry', () => {
+  it('retries on 429 and eventually succeeds', async () => {
+    axios.post
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockResolvedValueOnce({ data: { value: 'success' } });
+
+    const result = await callAPIWithRetry('test', 2, 10);
+
+    expect(axios.post).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ value: 'success' });
+  });
+});

--- a/app/api/route/route.js
+++ b/app/api/route/route.js
@@ -61,3 +61,6 @@ export async function POST(req) {
     );
   }
 }
+
+// Export for testing purposes
+export { callAPIWithRetry };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "autoprefixer": "^10.4.21",
@@ -23,6 +24,10 @@
     "@tailwindcss/postcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.1",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest test config and Babel preset
- add axios retry test for callAPIWithRetry
- expose callAPIWithRetry for tests
- add Jest dependencies and script to package.json

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847ef507620832a8eedc7b9353cb4b3