### PR TITLE
Fix message text in VoiceToText

### DIFF
--- a/components/VoiceToText.js
+++ b/components/VoiceToText.js
@@ -65,7 +65,7 @@ const VoiceToText = () => {
       setResponse(data.result); // Set GPT-3 response
     } catch (error) {
       console.error("Error:", error);
-      setResponse("Error occurred while fetching the translation.");
+      setResponse("Error occurred while fetching the summary.");
     }
   };
 
@@ -131,7 +131,7 @@ const VoiceToText = () => {
         <p className="text-lg text-gray-800">
           {isLoading
             ? "Loading..."
-            : response || "Translation or result will appear here"}
+            : response || "Summary or result will appear here"}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- correct error message to mention 'summary'
- update placeholder text displayed before the API result

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847eee9ef3c832a80dd11378aa35dc9